### PR TITLE
Implemented regexp for valid permissions

### DIFF
--- a/lib/accession/permission.rb
+++ b/lib/accession/permission.rb
@@ -1,5 +1,14 @@
 module Accession
   class Permission
+    # A segment is a "word" in the url-safe base64 alphabet, or single '*'
+    SEGMENT = /([\w-]+|\*)/.freeze
+    REGEXP = /\A(#{SEGMENT}:)*#{SEGMENT}\z/.freeze
+    private_constant :SEGMENT, :REGEXP
+
+    def self.regexp
+      REGEXP
+    end
+
     def initialize(value)
       @parts = value.split(':')
     end

--- a/spec/lib/accession/permission_spec.rb
+++ b/spec/lib/accession/permission_spec.rb
@@ -58,5 +58,21 @@ module Accession
       denies('a:b:c:e:d')
       denies('a:b:d:c')
     end
+
+    context '::regexp' do
+      subject { Accession::Permission.regexp }
+
+      it { is_expected.to match('*') }
+      it { is_expected.to match('a:b:c:d') }
+      it { is_expected.to match('a:b:c:*') }
+      it { is_expected.to match('a:b:*:d') }
+      it { is_expected.to match('word:word:word:__________') }
+      it { is_expected.to match('*:*:*:*:*:*:*:*:*:*:*:*:*:*:*:*:*:*:*:*:*:*') }
+      it { is_expected.not_to match('a:b:%') }
+      it { is_expected.not_to match('a:b:%:*') }
+      it { is_expected.not_to match('%') }
+      it { is_expected.not_to match('') }
+      it { is_expected.not_to match("*:*:*:*\n:*:*") }
+    end
   end
 end


### PR DESCRIPTION
I was just about to go write this for the second time, and decided to just extract it out into accession.

Intended to be used like:

``` ruby
class Permission < ActiveRecord::Base
  validates :value, presence: true, format: Accession::Permission.regexp
end
```
